### PR TITLE
Unset PERM_RAW when allocation is written to

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -266,12 +266,15 @@ impl Emulator {
         }
     }
 
-    pub fn run(&mut self) -> Result<(), VmExit> {
+    pub fn run(&mut self, instrs_execed: &mut u64) -> Result<(), VmExit> {
         'next_inst: loop {
             // Get the current program counter
             let pc = self.reg(Register::Pc);
             let inst: u32 = self.memory.read_perms(VirtAddr(pc as usize), 
                                                    Perm(PERM_EXEC))?;
+
+            // Update number of instructions executed
+            *instrs_execed += 1;
 
             // Extract the opcode from the instruction
             let opcode = inst & 0b1111111;

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -187,7 +187,7 @@ impl Mmu {
             perms.iter_mut().for_each(|x| {
                 if (x.0 & PERM_RAW) != 0 {
                     // Mark memory as readable
-                    *x = Perm(x.0 | PERM_READ);
+                    *x = Perm((x.0 | PERM_READ) & (!PERM_RAW));
                 }
             });
         }


### PR DESCRIPTION
The `has_raw` variable will always be true on all writes to allocated memory, even if it has already been written to. This means that you iterate through all permissions of all writes for no reason (the second time onwards), and this should probably only be done on the first write (at least that's what I thought the purpose of `PERM_RAW` was).

For example:
If the program does 1 (kind of small) allocation of 5KB and writes twice to the whole same allocation, you are iterating 5K times for no reason per program execution. If you have 1 million executions per sec you are iterating 5 billion times for no reason since those bytes already have their `PERM_READ` flag on them.

Also, I rechecked the vod and you misread the speedup not by checking permissions. It was about ~110x faster not just 1.2x. It went from 4.2 million fcps to 480 million fpcs (see attached screenshot from your stream for before & after).
This change will of course not give 110x speedup but it is a step in that direction without losing the permission system (so basically free).

[![https://imgur.com/Yio7fK8.png](https://imgur.com/Yio7fK8.png)](https://imgur.com/Yio7fK8.png)
Does not look very minor to me :)